### PR TITLE
Syntax error

### DIFF
--- a/osm/osm_cookiecontrol.js
+++ b/osm/osm_cookiecontrol.js
@@ -63,7 +63,7 @@ var config = {
 					onAccept: function() {},
 					onRevoke: function() {
 						CookieControl.delete('IDE');
-					},
+					}
 				},
 		    {
 			name: 'accept',


### PR DESCRIPTION
A miss typed comma was after advertising cookies, causing the category not to open after "Accept Cookies" event. It should be replaced in original script and tested again.